### PR TITLE
windows portable close bug fixed with .bat and pause command

### DIFF
--- a/windows_portable/data.csv:Zone.Identifier
+++ b/windows_portable/data.csv:Zone.Identifier
@@ -1,2 +1,0 @@
-[ZoneTransfer]
-ZoneId=3

--- a/windows_portable/run.bat
+++ b/windows_portable/run.bat
@@ -1,0 +1,3 @@
+@echo off
+main.exe
+pause


### PR DESCRIPTION
Previous windows run closed window after report. Fixed with bat file.